### PR TITLE
Improve glorious demo view on tablet

### DIFF
--- a/src/scripts/codes/views/demo/demo.html
+++ b/src/scripts/codes/views/demo/demo.html
@@ -1,6 +1,6 @@
 <viewport>
   <row vertical-centered>
-    <row-item size="6">
+    <row-item size="5">
       <code-view-summary
         heading="Glorious Demo"
         repository-name="glorious-demo"
@@ -8,7 +8,7 @@
         code-weight="4.6">
       </code-view-summary>
     </row-item>
-    <row-item size="6">
+    <row-item size="7">
       <demo-demo />
     </row-item>
   </row>

--- a/src/styles/btn.styl
+++ b/src/styles/btn.styl
@@ -3,6 +3,7 @@
 
 .btn
   position relative
+  margin 0
   padding 0 15px
   color $color-grey-dark
   background-color transparent

--- a/src/styles/editor.styl
+++ b/src/styles/editor.styl
@@ -8,6 +8,8 @@
   border-radius(3px)
   .codeflask
     background transparent
+  .codeflask__textarea
+    color transparent
   .token
     &.class-name
       color $color-blue


### PR DESCRIPTION
Resolves #23

- Better sized columns
- Removed button margins (left/right) on Safari

<img width="954" alt="screen shot 2018-11-03 at 14 50 10" src="https://user-images.githubusercontent.com/4738687/47955527-53374200-df78-11e8-9e4e-7da9a9b9d24c.png">
