### PR TITLE
Fix Safari word wrap issue

### DIFF
--- a/src/styles/editor.styl
+++ b/src/styles/editor.styl
@@ -8,6 +8,8 @@
   border-radius(3px)
   .codeflask
     background transparent
+  .codeflask__flatten
+    word-wrap normal
   .codeflask__textarea
     color transparent
   .token


### PR DESCRIPTION
Resolves #22 

Safari behaves strangely when using the CSS prop `white-space` in some cases. Adding, `word-wrap: normal` fixes this as seen [here](https://stackoverflow.com/questions/44754987/getting-osx-safari-to-honor-css-white-space-pre).