### PR TITLE
Fix badge visibility in code view summary

### DIFF
--- a/src/scripts/codes/components/code-view-summary/code-view-summary.html
+++ b/src/scripts/codes/components/code-view-summary/code-view-summary.html
@@ -4,7 +4,7 @@
       {{ tagline }}
       <br>
       <code-weight-badge
-        v-if="codeWeightBadgeText"
+        v-if="codeWeight"
         :text="codeWeightBadgeText" />
       <github-button-widget
         username="glorious-codes"

--- a/src/scripts/codes/components/code-view-summary/code-view-summary.test.js
+++ b/src/scripts/codes/components/code-view-summary/code-view-summary.test.js
@@ -3,6 +3,7 @@ import list from '@scripts/base/components/list/list';
 import listItem from '@scripts/base/components/list-item/list-item';
 import viewSummary from '@scripts/base/components/view-summary/view-summary';
 import codesBackLink from '@scripts/codes/components/codes-back-link/codes-back-link';
+import codeWeightBadge from '@scripts/codes/components/code-weight-badge/code-weight-badge';
 import codeViewSummary from './code-view-summary';
 
 describe('Code View Summary', () => {
@@ -70,8 +71,18 @@ describe('Code View Summary', () => {
     expect(externalLink.innerHTML.trim()).toEqual('See documentation');
   });
 
-  it('should set code weight badge text', () => {
+  it('should show code weight badge if code weight has been passed', () => {
+    const wrapper = mountComponent({ codeWeight: '4.6' });
+    expect(wrapper.contains(codeWeightBadge)).toEqual(true);
+  });
+
+  it('should set code weight badge text if code weight has been passed', () => {
     const wrapper = mountComponent({ codeWeight: '4.6' });
     expect(wrapper.vm.codeWeightBadgeText).toEqual('4.6kb Gzipped');
+  });
+
+  it('should not show code weight badge if no code weight has been passed', () => {
+    const wrapper = mountComponent();
+    expect(wrapper.contains(codeWeightBadge)).toEqual(false);
   });
 });

--- a/src/styles/code-view-summary.styl
+++ b/src/styles/code-view-summary.styl
@@ -4,7 +4,8 @@
     display inline-block
   .code-weight-badge
     margin-top 10px
+    & + .github-button-widget
+      left 10px
   .github-button-container
     position relative
     top 5.5px
-    left 10px

--- a/src/styles/github-button-widget.styl
+++ b/src/styles/github-button-widget.styl
@@ -1,4 +1,3 @@
 .github-button-widget
   position relative
   top 6px
-  left 10px


### PR DESCRIPTION
Resolves #26 

Hiding badge if no code weight has been passed:

<img width="393" alt="screen shot 2018-11-04 at 15 31 56" src="https://user-images.githubusercontent.com/4738687/47967644-c9a27580-e046-11e8-9005-d3b9b2400974.png">
