### PR TITLE
Fix font-size for Glorious Demo editor

### DIFF
--- a/src/styles/editor.styl
+++ b/src/styles/editor.styl
@@ -1,6 +1,8 @@
 @require '_variables'
 @require '_mixins'
 
+$font-size = 13px
+
 .editor
   position relative
   height 400px
@@ -9,6 +11,7 @@
   .codeflask
     background transparent
   .codeflask__flatten
+    font-size $font-size
     word-wrap normal
   .codeflask__textarea
     color transparent
@@ -27,4 +30,5 @@
   pre[class*=language-]
     background none
     color inherit
+    font-size $font-size
     line-height 20px


### PR DESCRIPTION
A conflict between font-sizes was making editor impossible to use.